### PR TITLE
CSS correction to fill header properly on screen

### DIFF
--- a/searchAreaControl/css/sac-style.css
+++ b/searchAreaControl/css/sac-style.css
@@ -29,6 +29,7 @@
 .sac-header-holder {
     width:100%;   
     margin-bottom: 15px; 
+    display: flex;
 }
 
 .sac-header-h1 {
@@ -44,7 +45,7 @@
 }
 
 .sac-input-elem {
-    width: 200px;
+    flex: 1;
     height: 32px;
     border: 1px solid #d8d8d8;
     padding: 5px;


### PR DESCRIPTION
In my tests the header was smaller than the width of the screen. I changed the header css to flex mode, so regardless of the width, the header will always have the same alignment.